### PR TITLE
Workforce Utilization Dashboard Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,40 @@ Please implement a dashboard that has the structure of the table below:
 
 - All fields that fetch data (e.g. Net earnings prev Month) are fetched correctly for each cell
 - All mathematical operations are correctly performed and displayed in an intuitive way
+
+###  Implementation Details
+Active Persons Only:
+Only persons with status "active" are shown in the table.
+
+Utilization Rates:
+The utilization rates for the past 12 months, year-to-date, and the last three individual months (May, June, July) are extracted from the data and displayed as percentages. If a value is missing, a dash (-) is shown.
+
+Net Earnings Previous Month:
+The net earnings for the previous month are dynamically determined using the current date and displayed in EUR. If no data is available, a dash (-) is shown.
+
+Data Processing:
+
+All data is loaded from source-data.json.
+
+In table-script.tsx, the data is filtered and mapped to match the table requirements.
+
+Helper functions are used:
+
+getNetEarningsForMonth: Finds the net earnings for a given month (format: YYYY-MM) in the potentialEarningsByMonth array.
+
+getUtilizationForMonth: Finds the utilization rate for a specific month (e.g., "June") from the lastThreeMonthsIndividually array and formats it as a percentage.
+
+The code uses date-fns to calculate the previous month and handle date formatting.
+
+Table Rendering:
+The Table component uses Material React Table to render the processed data with the required column headers.
+
+Example Table Row:
+
+| Person        | Past 12 Months | Y2D | May | June | July | Net Earnings Prev Month |
+| ----------    | -------------- | --- | --- | ---- | ---- | ----------------------- |
+| Justus Peter  |  67%           | 67% | -   | 0%   | 67%  | 0 EUR                   |
+
+Extensibility:
+To add more months or columns, adjust the mapping and column definitions in table-script.tsx.
+To change the data source, update source-data.json accordingly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,14 @@
         "@mui/icons-material": "^5.16.5",
         "@mui/material": "^5.16.5",
         "@mui/x-date-pickers": "^7.11.1",
+        "date-fns": "^3.6.0",
         "dayjs": "^1.11.12",
         "material-react-table": "^2.13.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@types/date-fns": "^2.5.3",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
@@ -1562,6 +1564,13 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/date-fns": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@types/date-fns/-/date-fns-2.5.3.tgz",
+      "integrity": "sha512-4KVPD3g5RjSgZtdOjvI/TDFkLNUHhdoWxmierdQbDeEg17Rov0hbBYtIzNaQA67ORpteOhvR9YEMTb6xeDCang==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -1774,6 +1783,16 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.12",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "@mui/icons-material": "^5.16.5",
     "@mui/material": "^5.16.5",
     "@mui/x-date-pickers": "^7.11.1",
+    "date-fns": "^3.6.0",
     "dayjs": "^1.11.12",
     "material-react-table": "^2.13.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/date-fns": "^2.5.3",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/src/source-data.json
+++ b/src/source-data.json
@@ -1,20 +1,1834 @@
 [
-    {"employees":{"birthday":"2000-05-25","firstname":"Justus","_mrn":"mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/cd1eb663-87d5-4ce3-8e72-a8201ebdb1e2","_createdDate":"2024-07-16T16:04:38Z","jobTitle":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==","hourlyRateForProjects":"20","costsByMonth":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","potentialEarningsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"0","month":"2024-04"},{"costs":"0","month":"2024-05"},{"costs":"0","month":"2024-06"},{"costs":"0","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_updatedDate":"1723202172448","_definitionId":"6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5","_createdDate":"1721145882092"},"_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/f56454f7-c20e-42db-8cfa-4cb2b288eeb3","usedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==","_archived":"false","statusAggregation":{"monthlySalary":"null","_updatedDate":"1723202164134","yearlyVacationDays":"null","_createdDate":"1721145879322","jobTitle":"null","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","weeklyWorkingHours":"null","jobType":"null","_definitionId":"1da52573-107e-4c2c-b349-d59f791f3d75","status":"Inaktiv"},"jobType":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==","address":{"country":"AS","streetName":"asdasda","locality":"Giieee"},"hoursPerWeek":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==","_updatedDate":"2024-07-28T11:03:59Z","team":"mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/3d82f5f0-65f5-4b01-a028-4e44334ba94a","targetWorkingHours":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==","lastname":"Peter","holidayPerYear":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==","workforceUtilisation":{"_updatedDate":"1723202184886","totalCostPerCustomer":"120.00","_createdDate":"1721145879688","utilisationRateOngoingQuarter":"0.67","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"3200.0","utilisationRateLastTwelveMonths":"0.67","quarterEarnings":[{"earnings":"0.0","start":"2024-01-01","name":"Q1","end":"2024-03-31"},{"earnings":"0.0","start":"2024-04-01","name":"Q2","end":"2024-06-30"},{"earnings":"120.0","start":"2024-07-01","name":"Q3","end":"2024-09-30"},{"earnings":"0.0","start":"2024-10-01","name":"Q4","end":"2024-12-31"}],"timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"0.67","utilisationRateYearToDate":"0.67","utilisationRatePreviousQuarter":"0.00","_definitionId":"d0448e0f-4225-4196-bd45-8b70730bd397","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.67"},{"month":"June","utilisationRate":"0.00"}]},"name":"Justus Peter","earnedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==","_id":"cd1eb663-87d5-4ce3-8e72-a8201ebdb1e2","individualTicketDuration":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz","searchValue":"justus peter mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2nkmwvinjyzltg3zdutngnlmy04ztcylwe4mjaxzwjkyjflmg==","status":"active"}},
-    {"employees":{"birthday":"1992-05-30","firstname":"Lustig","_mrn":"mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/c50d2396-97de-48dd-a0c0-c4709e869f5b","_createdDate":"2024-06-06T08:23:22Z","jobTitle":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==","hourlyRateForProjects":"5","costsByMonth":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","potentialEarningsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"0","month":"2024-04"},{"costs":"0","month":"2024-05"},{"costs":"0","month":"2024-06"},{"costs":"0","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_updatedDate":"1723202172555","_definitionId":"6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5","_createdDate":"1717662205927"},"_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/fdc450ba-b43f-4010-b7b5-9f830d53732d","authUser":"mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/21406cd2-c9fd-41c2-a8b1-ff68dfc2f0d3","usedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==","_archived":"false","statusAggregation":{"monthlySalary":"null","_updatedDate":"1723202164312","yearlyVacationDays":"null","_createdDate":"1717662202719","jobTitle":"null","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","weeklyWorkingHours":"null","jobType":"null","_definitionId":"1da52573-107e-4c2c-b349-d59f791f3d75","status":"Inaktiv"},"jobType":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==","address":{"country":"DE","streetName":"Test","postalCode":"12345","locality":"Berlin","houseNumber":"123"},"hoursPerWeek":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==","_updatedDate":"2024-07-28T11:04:32Z","targetWorkingHours":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==","lastname":"Sophie","holidayPerYear":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==","workforceUtilisation":{"_updatedDate":"1723202185821","totalCostPerCustomer":"0.00","_createdDate":"1721125125055","utilisationRateOngoingQuarter":"0.00","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"0.00","quarterEarnings":[{"earnings":"0.0","start":"2024-01-01","name":"Q1","end":"2024-03-31"},{"earnings":"0.0","start":"2024-04-01","name":"Q2","end":"2024-06-30"},{"earnings":"0.0","start":"2024-07-01","name":"Q3","end":"2024-09-30"},{"earnings":"0.0","start":"2024-10-01","name":"Q4","end":"2024-12-31"}],"timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"0.00","utilisationRateYearToDate":"0.00","utilisationRatePreviousQuarter":"0.00","_definitionId":"d0448e0f-4225-4196-bd45-8b70730bd397","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.00"},{"month":"June","utilisationRate":"0.00"}]},"websiteInformation":{"secret":"zehnteapril3005"},"name":"Lustig Sophie","salutation":"Herr","earnedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==","_id":"c50d2396-97de-48dd-a0c0-c4709e869f5b","individualTicketDuration":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz","searchValue":"lustig sophie mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2m1mgqymzk2ltk3zgutndhkzc1hmgmwlwm0nza5ztg2owy1yg==","status":"active"}},
-    {"employees":{"birthday":"2024-05-11","firstname":"Neumann","documents":[{"image":"https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/59434b7b-ed08-47bd-88a3-ae634083f087/Document.pdf"}],"_mrn":"mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/bcf37ecd-36f4-4a8d-a732-5c833de88d2c","_createdDate":"2024-05-09T14:02:09Z","jobTitle":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==","costsByMonth":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","potentialEarningsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"0","month":"2024-04"},{"costs":"0","month":"2024-05"},{"costs":"0","month":"2024-06"},{"costs":"0","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_updatedDate":"1723202172656","_definitionId":"6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5","_createdDate":"1715263333140"},"_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/afd9447f-b750-4b1c-9ade-02956f90950e","authUser":"mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/273322a6-d830-4758-b140-5f0b9bee938f","usedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==","_archived":"false","statusAggregation":{"monthlySalary":"null","_updatedDate":"1723202164421","yearlyVacationDays":"null","_createdDate":"1715263329918","jobTitle":"null","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","weeklyWorkingHours":"null","jobType":"null","_definitionId":"1da52573-107e-4c2c-b349-d59f791f3d75","status":"Inaktiv"},"jobType":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==","email":"amelie.neumann.fake@micromerce.com","address":{"country":"IN","streetName":"Street 1","locality":"Kerala"},"hoursPerWeek":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==","_updatedDate":"2024-07-28T11:05:02Z","photo":"https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/d8e87051-32bd-4a8c-9a48-94d5bae0bf0b/beautiful-hologram-water-color-frame-png_119551.jpg","targetWorkingHours":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==","lastname":"Amelie","holidayPerYear":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==","slackId":"D06VD0JAPKM","workforceUtilisation":{"_updatedDate":"1723202185722","totalCostPerCustomer":"0.00","_createdDate":"1721125127119","utilisationRateOngoingQuarter":"0.00","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"0.00","quarterEarnings":[{"earnings":"0.0","start":"2024-01-01","name":"Q1","end":"2024-03-31"},{"earnings":"0.0","start":"2024-04-01","name":"Q2","end":"2024-06-30"},{"earnings":"0.0","start":"2024-07-01","name":"Q3","end":"2024-09-30"},{"earnings":"0.0","start":"2024-10-01","name":"Q4","end":"2024-12-31"}],"timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"0.00","utilisationRateYearToDate":"0.00","utilisationRatePreviousQuarter":"0.00","_definitionId":"d0448e0f-4225-4196-bd45-8b70730bd397","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.00"},{"month":"June","utilisationRate":"0.00"}]},"name":"Neumann Amelie","salutation":"Frau","earnedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==","_id":"bcf37ecd-36f4-4a8d-a732-5c833de88d2c","individualTicketDuration":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz","searchValue":"neumann amelie mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2jjzjm3zwnkltm2zjqtnge4zc1hnzmyltvjodmzzgu4ogqyyw==","status":"active"}},
-    {"employees":{"birthday":"2024-05-11","firstname":"Groß","documents":[{"image":"https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/59434b7b-ed08-47bd-88a3-ae634083f087/Document.pdf"}],"_mrn":"mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/5bddc396-6343-4451-911b-e91837e42b97","_createdDate":"2024-05-07T09:55:45Z","jobTitle":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==","costsByMonth":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","potentialEarningsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"0","month":"2024-04"},{"costs":"0","month":"2024-05"},{"costs":"0","month":"2024-06"},{"costs":"0","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_updatedDate":"1723202172745","_definitionId":"6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5","_createdDate":"1715075749406"},"_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/ae00e09d-6d53-4f98-a6be-f74b6dd635e2","authUser":"mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/273322a6-d830-4758-b140-5f0b9bee938f","usedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==","_archived":"false","statusAggregation":{"monthlySalary":"null","_updatedDate":"1723202164591","yearlyVacationDays":"null","_createdDate":"1715075747290","jobTitle":"null","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","weeklyWorkingHours":"null","jobType":"null","_definitionId":"1da52573-107e-4c2c-b349-d59f791f3d75","status":"Inaktiv"},"jobType":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==","email":"julius@micromerce.com","address":{"country":"IN","streetName":"Street 1","locality":"Kerala"},"hoursPerWeek":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==","_updatedDate":"2024-07-28T11:05:35Z","photo":"https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/d8e87051-32bd-4a8c-9a48-94d5bae0bf0b/beautiful-hologram-water-color-frame-png_119551.jpg","targetWorkingHours":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==","lastname":"Julius","holidayPerYear":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==","slackId":"D06VD0JAPKM","workforceUtilisation":{"_updatedDate":"1723202185600","totalCostPerCustomer":"0.00","_createdDate":"1721125129181","utilisationRateOngoingQuarter":"0.00","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"0.00","quarterEarnings":[{"earnings":"0.0","start":"2024-01-01","name":"Q1","end":"2024-03-31"},{"earnings":"0.0","start":"2024-04-01","name":"Q2","end":"2024-06-30"},{"earnings":"0.0","start":"2024-07-01","name":"Q3","end":"2024-09-30"},{"earnings":"0.0","start":"2024-10-01","name":"Q4","end":"2024-12-31"}],"timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"0.00","utilisationRateYearToDate":"0.00","utilisationRatePreviousQuarter":"0.00","_definitionId":"d0448e0f-4225-4196-bd45-8b70730bd397","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.00"},{"month":"June","utilisationRate":"0.00"}]},"name":"Groß Julius","salutation":"Frau","earnedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==","_id":"5bddc396-6343-4451-911b-e91837e42b97","individualTicketDuration":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz","searchValue":"groß julius mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzlzvizgrjmzk2ltyzndmtndq1ms05mtfilwu5mtgzn2u0mmi5nw==","status":"active"}},
-    {"employees":{"birthday":"2024-04-10","firstname":"Bredolph","_mrn":"mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/42c0434b-497d-4848-bc03-9a2a2ddb531f","_createdDate":"2024-04-09T09:11:34Z","jobTitle":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","costsByMonth":{"_updatedDate":"1723202173498","_createdDate":"1713173714530","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","periods":[{"monthlySalary":"3000","start":"2024-04-19","end":"2024-05-23"}],"potentialEarningsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"1342","month":"2024-04"},{"costs":"2567","month":"2024-05"},{"costs":"0","month":"2024-06"},{"costs":"0","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_definitionId":"6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5"},"utilisationRateLastTwelveMonths":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-employee/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/f677cb20-2cb0-465e-991c-ff6a85bcf5ef","utilisationRate":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-customer/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","existingPayrollCount":"6","usedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","workforceUtilisation2":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-employee/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","_archived":"false","statusAggregation":{"monthlySalary":"3000","_updatedDate":"1723202164692","yearlyVacationDays":"30","_createdDate":"1712653894771","jobTitle":"QA Consultant","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","weeklyWorkingHours":"40","jobType":"vollzeit","_definitionId":"1da52573-107e-4c2c-b349-d59f791f3d75","status":"Inaktiv"},"jobType":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","hoursPerWeek":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","address":{"country":"DE","streetName":"Horkelbräuscherstraße","locality":"Gronkelbecken an der Leine"},"_updatedDate":"2024-06-07T15:32:36Z","sickNotesPreviousAmount":"2","targetWorkingHours":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","lastname":"Hanseljauch","holidayPerYear":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","workforceUtilisation":{"_updatedDate":"1723202185341","totalCostPerCustomer":"0.00","_createdDate":"1721125131246","utilisationRateOngoingQuarter":"0.00","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"0.00","quarterEarnings":[{"earnings":"0.0","start":"2024-01-01","name":"Q1","end":"2024-03-31"},{"earnings":"0.0","start":"2024-04-01","name":"Q2","end":"2024-06-30"},{"earnings":"0.0","start":"2024-07-01","name":"Q3","end":"2024-09-30"},{"earnings":"0.0","start":"2024-10-01","name":"Q4","end":"2024-12-31"}],"timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"0.00","utilisationRateYearToDate":"0.00","utilisationRatePreviousQuarter":"0.00","_definitionId":"d0448e0f-4225-4196-bd45-8b70730bd397","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.00"},{"month":"June","utilisationRate":"0.00"}]},"name":"Bredolph Hanseljauch","earnedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","_id":"42c0434b-497d-4848-bc03-9a2a2ddb531f","searchValue":"bredolph hanseljauch mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzlzqyyza0mzriltq5n2qtndg0oc1iyzazltlhmmeyzgrintmxzg==","bookedTimeOverview":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/booked-time-overview/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==","individualTicketDuration":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz","status":"active"}},
-    {"employees":{"birthday":"2024-04-24","firstname":"World","_mrn":"mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/ae2fbd9a-dbe2-4f5f-95a3-645099f2577f","_createdDate":"2024-04-09T08:56:13Z","jobTitle":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","costsByMonth":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","potentialEarningsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"0","month":"2024-04"},{"costs":"0","month":"2024-05"},{"costs":"0","month":"2024-06"},{"costs":"0","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_updatedDate":"1723202173622","_definitionId":"6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5","_createdDate":"1713173108444"},"utilisationRateLastTwelveMonths":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-employee/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/f677cb20-2cb0-465e-991c-ff6a85bcf5ef","utilisationRate":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-customer/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","usedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","workforceUtilisation2":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-employee/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","_archived":"false","statusAggregation":{"monthlySalary":"null","_updatedDate":"1723202164800","yearlyVacationDays":"null","_createdDate":"1712652973623","jobTitle":"null","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","weeklyWorkingHours":"null","jobType":"null","_definitionId":"1da52573-107e-4c2c-b349-d59f791f3d75","status":"Inaktiv"},"jobType":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","hoursPerWeek":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","address":{"country":"DE","streetName":"Hausstraße","locality":"Zweihügel"},"_updatedDate":"2024-04-27T10:24:53Z","sickNotesPreviousAmount":"2","targetWorkingHours":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","lastname":"Hello","holidayPerYear":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","workforceUtilisation":{"_updatedDate":"1723202185240","totalCostPerCustomer":"0.00","_createdDate":"1721125133310","utilisationRateOngoingQuarter":"0.00","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"0.00","quarterEarnings":[{"earnings":"0.0","start":"2024-01-01","name":"Q1","end":"2024-03-31"},{"earnings":"0.0","start":"2024-04-01","name":"Q2","end":"2024-06-30"},{"earnings":"0.0","start":"2024-07-01","name":"Q3","end":"2024-09-30"},{"earnings":"0.0","start":"2024-10-01","name":"Q4","end":"2024-12-31"}],"timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"0.00","utilisationRateYearToDate":"0.00","utilisationRatePreviousQuarter":"0.00","_definitionId":"d0448e0f-4225-4196-bd45-8b70730bd397","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.00"},{"month":"June","utilisationRate":"0.00"}]},"name":"World Hello","earnedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","_id":"ae2fbd9a-dbe2-4f5f-95a3-645099f2577f","searchValue":"world hello mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2flmmzizdlhlwriztitngy1zi05nwezlty0nta5owyyntc3zg==","bookedTimeOverview":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/booked-time-overview/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==","individualTicketDuration":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz","status":"active"}},
-    {"employees":{"birthday":"2023-01-01","firstname":"Musterperson","_mrn":"mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/c917942d-737e-4b8d-a3b2-6a82c1c3d88a","_createdDate":"2024-01-03T15:55:23Z","jobTitle":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==","hourlyRateForProjects":"30","costsByMonth":{"_updatedDate":"1723202173348","_createdDate":"1713202691098","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","periods":[{"monthlySalary":"2000","start":"2023-04-01","end":"2023-10-14"},{"monthlySalary":"1000","start":"2023-10-15","end":"2024-01-31"},{"monthlySalary":"2000","start":"2024-02-01","end":"null"}],"potentialEarningsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"2460","month":"2023-04"},{"costs":"2460","month":"2023-05"},{"costs":"2460","month":"2023-06"},{"costs":"2460","month":"2023-07"},{"costs":"2460","month":"2023-08"},{"costs":"2460","month":"2023-09"},{"costs":"1789","month":"2023-10"},{"costs":"1230","month":"2023-11"},{"costs":"1230","month":"2023-12"},{"costs":"1177","month":"2024-01"},{"costs":"2460","month":"2024-02"},{"costs":"2460","month":"2024-03"},{"costs":"2460","month":"2024-04"},{"costs":"2460","month":"2024-05"},{"costs":"2460","month":"2024-06"},{"costs":"2460","month":"2024-07"},{"costs":"2460","month":"2024-08"},{"costs":"2460","month":"2024-09"},{"costs":"2460","month":"2024-10"},{"costs":"2460","month":"2024-11"},{"costs":"2460","month":"2024-12"},{"costs":"2460","month":"2025-01"},{"costs":"2460","month":"2025-02"},{"costs":"2460","month":"2025-03"},{"costs":"2460","month":"2025-04"},{"costs":"2460","month":"2025-05"},{"costs":"2460","month":"2025-06"},{"costs":"2460","month":"2025-07"},{"costs":"2460","month":"2025-08"}],"_definitionId":"6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5"},"_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a50976c6-fc81-4cc9-af8f-c30d08554307","usedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==","lastTimelogDailyReminderSentDate":"2024-02-14","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==","_archived":"false","statusAggregation":{"monthlySalary":"2000","_updatedDate":"1723202165420","yearlyVacationDays":"30","_createdDate":"1704827393774","jobTitle":"Technical Customer Success Manager","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","weeklyWorkingHours":"40","jobType":"vollzeit","_definitionId":"1da52573-107e-4c2c-b349-d59f791f3d75","status":"Aktiv"},"jobType":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==","email":"maximilian.weber+for-termination@micromerce.com","address":{"country":"AT","streetName":"Große Karottengasse","postalCode":"1020","locality":"Wien","houseNumber":"14"},"hoursPerWeek":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==","_updatedDate":"2024-07-30T12:59:00Z","sickNotesPreviousAmount":"3","photo":"https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/ba8f8f4a-7a0c-48d2-8fec-2fcac94b1386/Florian.png","team":"mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/774cb064-e0c6-448a-a338-4d50087469d1","targetWorkingHours":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==","lastname":"Enja","holidayPerYear":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==","workforceUtilisation":{"_updatedDate":"1723202186776","totalCostPerCustomer":"45.00","_createdDate":"1721117704495","utilisationRateOngoingQuarter":"0.00","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"4800.0","utilisationRateLastTwelveMonths":"1.00","quarterEarnings":[{"earnings":"0.0","start":"2024-01-01","name":"Q1","end":"2024-03-31"},{"earnings":"45.0","start":"2024-04-01","name":"Q2","end":"2024-06-30"},{"earnings":"0.0","start":"2024-07-01","name":"Q3","end":"2024-09-30"},{"earnings":"0.0","start":"2024-10-01","name":"Q4","end":"2024-12-31"}],"timeWorkedPreviousQuarter":"1.5","utilisationRateOverall":"1.00","utilisationRateYearToDate":"1.00","utilisationRatePreviousQuarter":"1.00","_definitionId":"d0448e0f-4225-4196-bd45-8b70730bd397","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.00"},{"month":"June","utilisationRate":"0.00"}]},"websiteInformation":{"hubspotUrl":"http://awd.de","secret":"12345"},"name":"Musterperson Enja","earnedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==","_id":"c917942d-737e-4b8d-a3b2-6a82c1c3d88a","searchValue":"musterperson enja mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2m5mtc5ndjkltczn2utngi4zc1hm2iyltzhodjjmwmzzdg4yq==","status":"active"}},
-    {"employees":{"birthday":"1999-01-31","firstname":"Grünelinde","_mrn":"mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/6c072f15-64f9-4d79-b218-f606c00c98d8","_createdDate":"2023-05-16T13:20:20Z","jobTitle":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==","costsByMonth":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","potentialEarningsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"0","month":"2024-04"},{"costs":"0","month":"2024-05"},{"costs":"0","month":"2024-06"},{"costs":"0","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_updatedDate":"1723202173204","_definitionId":"6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5","_createdDate":"1713202693396"},"_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a50976c6-fc81-4cc9-af8f-c30d08554307","authUser":"mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/51994c43-d7ab-4936-81d4-51426896173e","usedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==","_archived":"false","statusAggregation":{"monthlySalary":"null","_updatedDate":"1723202165309","yearlyVacationDays":"null","_createdDate":"1704827393801","jobTitle":"null","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","weeklyWorkingHours":"null","jobType":"null","_definitionId":"1da52573-107e-4c2c-b349-d59f791f3d75","status":"Inaktiv"},"jobType":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==","email":"charlotte.gruenelinde@micromerce.com","address":{"country":"AL","streetName":"Test","postalCode":"12345","locality":"Hamburg","houseNumber":"1"},"hoursPerWeek":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==","_updatedDate":"2024-07-28T11:07:55Z","fallbackJobTitle":"Frontend Entwickler","targetWorkingHours":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==","lastname":"Charlotte","holidayPerYear":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==","phone":"12345","workforceUtilisation":{"_updatedDate":"1723202186576","totalCostPerCustomer":"210.00","_createdDate":"1721117793866","utilisationRateOngoingQuarter":"0.00","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"0.10","quarterEarnings":[{"earnings":"0.0","start":"2024-01-01","name":"Q1","end":"2024-03-31"},{"earnings":"0.0","start":"2024-04-01","name":"Q2","end":"2024-06-30"},{"earnings":"0.0","start":"2024-07-01","name":"Q3","end":"2024-09-30"},{"earnings":"0.0","start":"2024-10-01","name":"Q4","end":"2024-12-31"}],"timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"0.14","utilisationRateYearToDate":"0.00","utilisationRatePreviousQuarter":"0.00","_definitionId":"d0448e0f-4225-4196-bd45-8b70730bd397","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.00"},{"month":"June","utilisationRate":"0.00"}]},"websiteInformation":{"hubspotUrl":"https://micromerce-solutions.com/meetings/robert-bernhardt","secret":"1234232134234234"},"name":"Grünelinde Charlotte","salutation":"Herr","earnedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==","_id":"6c072f15-64f9-4d79-b218-f606c00c98d8","individualTicketDuration":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz","searchValue":"grünelinde charlotte mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzlzzjmdcyzje1lty0zjktngq3os1imje4lwy2mdzjmdbjothkoa==","status":"active"}},
-    {"employees":{"birthday":"1985-12-28","firstname":"Johnson","_mrn":"mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/fd5c4fd7-08dd-4bf9-898e-cc1e275e144d","_createdDate":"2023-04-11T09:19:40Z","jobTitle":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==","costsByMonth":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","potentialEarningsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"0","month":"2024-04"},{"costs":"0","month":"2024-05"},{"costs":"0","month":"2024-06"},{"costs":"0","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_updatedDate":"1723202173093","_definitionId":"6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5","_createdDate":"1713202697577"},"_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a50976c6-fc81-4cc9-af8f-c30d08554307","authUser":"mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/f120c511-abbf-4ee2-a682-11ce9eb2df67","usedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==","_archived":"false","statusAggregation":{"monthlySalary":"null","_updatedDate":"1723202164918","yearlyVacationDays":"null","_createdDate":"1704827393844","jobTitle":"null","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","weeklyWorkingHours":"null","jobType":"null","_definitionId":"1da52573-107e-4c2c-b349-d59f791f3d75","status":"Inaktiv"},"jobType":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==","email":"richard.johnson@micromerce.com","address":{"country":"DE","streetName":"Sandweg","postalCode":"34225","locality":"Baunatal","houseNumber":"3"},"hoursPerWeek":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==","_updatedDate":"2024-07-28T11:02:41Z","photo":"https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/bfb418ab-d198-452e-ad2b-23c655e5293e/avatar_02.png","targetWorkingHours":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==","lastname":"Richard","holidayPerYear":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==","workforceUtilisation":{"_updatedDate":"1723202186071","totalCostPerCustomer":"360.00","_createdDate":"1721118449814","utilisationRateOngoingQuarter":"0.00","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"1.00","quarterEarnings":[{"earnings":"0.0","start":"2024-01-01","name":"Q1","end":"2024-03-31"},{"earnings":"0.0","start":"2024-04-01","name":"Q2","end":"2024-06-30"},{"earnings":"0.0","start":"2024-07-01","name":"Q3","end":"2024-09-30"},{"earnings":"0.0","start":"2024-10-01","name":"Q4","end":"2024-12-31"}],"timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"1.00","utilisationRateYearToDate":"0.00","utilisationRatePreviousQuarter":"0.00","_definitionId":"d0448e0f-4225-4196-bd45-8b70730bd397","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.00"},{"month":"June","utilisationRate":"0.00"}]},"name":"Johnson Richard","salutation":"Herr","earnedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==","_id":"fd5c4fd7-08dd-4bf9-898e-cc1e275e144d","individualTicketDuration":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz","searchValue":"johnson richard mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2zknwm0zmq3lta4zgqtngjmos04othllwnjmwuynzvlmtq0za==","status":"active"}},
-    {"employees":{"birthday":"2022-01-01","firstname":"Max","_mrn":"mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/357fca21-8011-4420-b130-dec7748fa7c2","_createdDate":"2023-01-27T11:08:44Z","jobTitle":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==","costsByMonth":{"_updatedDate":"1723202172987","_createdDate":"1713202701745","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","periods":[{"monthlySalary":"3000","start":"2024-02-01","end":"null"}],"potentialEarningsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"3690","month":"2024-02"},{"costs":"3690","month":"2024-03"},{"costs":"3690","month":"2024-04"},{"costs":"3690","month":"2024-05"},{"costs":"3690","month":"2024-06"},{"costs":"3690","month":"2024-07"},{"costs":"3690","month":"2024-08"},{"costs":"3690","month":"2024-09"},{"costs":"3690","month":"2024-10"},{"costs":"3690","month":"2024-11"},{"costs":"3690","month":"2024-12"},{"costs":"3690","month":"2025-01"},{"costs":"3690","month":"2025-02"},{"costs":"3690","month":"2025-03"},{"costs":"3690","month":"2025-04"},{"costs":"3690","month":"2025-05"},{"costs":"3690","month":"2025-06"},{"costs":"3690","month":"2025-07"},{"costs":"3690","month":"2025-08"}],"_definitionId":"6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5"},"_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a50976c6-fc81-4cc9-af8f-c30d08554307","authUser":"mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/273322a6-d830-4758-b140-5f0b9bee938f","usedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==","lastTimelogDailyReminderSentDate":"2024-08-09","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==","_archived":"false","statusAggregation":{"monthlySalary":"3000","_updatedDate":"1723202165202","yearlyVacationDays":"30","_createdDate":"1704827393818","jobTitle":"Entwickler","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","weeklyWorkingHours":"40","jobType":"vollzeit","_definitionId":"1da52573-107e-4c2c-b349-d59f791f3d75","status":"Aktiv"},"jobType":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==","address":{"country":"DE","streetName":"Musterstraße","postalCode":"20457","locality":"Hamburg","houseNumber":"8"},"hoursPerWeek":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==","_updatedDate":"2024-08-09T11:45:52Z","photo":"https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/c966c89b-e1d6-4bd7-9270-ea3c55ac4cb8/Eva%20Avatar.png","team":"mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/aa59773b-4c4e-4304-82c8-274c33d0c8df","targetWorkingHours":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==","lastname":"Mustermann","holidayPerYear":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==","slackId":"U065LFQ2JCU","workforceUtilisation":{"_updatedDate":"1723202186285","totalCostPerCustomer":"1480.00","_createdDate":"1721118293236","utilisationRateOngoingQuarter":"1.00","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"1.00","quarterEarnings":[{"earnings":"720.0","start":"2024-01-01","name":"Q1","end":"2024-03-31"},{"earnings":"360.0","start":"2024-04-01","name":"Q2","end":"2024-06-30"},{"earnings":"280.0","start":"2024-07-01","name":"Q3","end":"2024-09-30"},{"earnings":"0.0","start":"2024-10-01","name":"Q4","end":"2024-12-31"}],"timeWorkedPreviousQuarter":"9.0","utilisationRateOverall":"1.00","utilisationRateYearToDate":"1.00","utilisationRatePreviousQuarter":"1.00","_definitionId":"d0448e0f-4225-4196-bd45-8b70730bd397","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"1.00"},{"month":"June","utilisationRate":"0.00"}]},"name":"Max Mustermann","earnedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==","_id":"357fca21-8011-4420-b130-dec7748fa7c2","searchValue":"max mustermann mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzlzm1n2zjytixltgwmtetndqymc1imtmwlwrlyzc3ndhmytdjmg==","status":"active"}},
-    {"employees":{"birthday":"1983-01-29","firstname":"Rom","_mrn":"mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/9946a5c7-0845-4575-86e0-32bf3e746ae2","_createdDate":"2021-05-16T10:00:02Z","jobTitle":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==","costsByMonth":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","potentialEarningsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"0","month":"2024-04"},{"costs":"0","month":"2024-05"},{"costs":"0","month":"2024-06"},{"costs":"0","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_updatedDate":"1723202172847","_definitionId":"6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5","_createdDate":"1713202705920"},"authUser":"mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/9ca3299c-3286-46f7-855d-7a970bf2c624","usedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==","_archived":"false","statusAggregation":{"monthlySalary":"null","_updatedDate":"1723202165080","yearlyVacationDays":"null","_createdDate":"1704827393822","jobTitle":"null","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","weeklyWorkingHours":"null","jobType":"null","_definitionId":"1da52573-107e-4c2c-b349-d59f791f3d75","status":"Inaktiv"},"jobType":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==","email":"remus.rom@micromerce.com","address":{"country":"DE","streetName":"Bahnhofsstraße","postalCode":"20457","locality":"Hamburg","houseNumber":"15"},"hoursPerWeek":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==","_updatedDate":"2024-07-28T11:09:36Z","photo":"https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/e33fcab9-70b6-45d3-a15b-8fe9adbcd223/img.png","targetWorkingHours":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==","lastname":"Remus","holidayPerYear":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==","phone":"+491796604600","workforceUtilisation":{"_updatedDate":"1723202185153","totalCostPerCustomer":"160.00","_createdDate":"1721139436511","utilisationRateOngoingQuarter":"0.50","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"0.50","quarterEarnings":[{"earnings":"0.0","start":"2024-01-01","name":"Q1","end":"2024-03-31"},{"earnings":"0.0","start":"2024-04-01","name":"Q2","end":"2024-06-30"},{"earnings":"0.0","start":"2024-07-01","name":"Q3","end":"2024-09-30"},{"earnings":"160.0","start":"2024-10-01","name":"Q4","end":"2024-12-31"}],"timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"0.50","utilisationRateYearToDate":"0.50","utilisationRatePreviousQuarter":"0.00","_definitionId":"d0448e0f-4225-4196-bd45-8b70730bd397","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.00"},{"month":"June","utilisationRate":"0.00"}]},"name":"Rom Remus","earnedVacationDays":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==","_id":"9946a5c7-0845-4575-86e0-32bf3e746ae2","individualTicketDuration":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz","searchValue":"rom remus mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzlzk5ndzhnwm3lta4ndutndu3ns04nmuwltmyymyzztc0nmflmg==","status":"active"}},
-    {"externals":{"birthday":"1980-10-14","firstname":"Mustermann","address":{"country":"DE","streetName":"Große Reichenstraße","postalCode":"20457","locality":"Hamburg","houseNumber":"14"},"_updatedDate":"2024-07-15T12:13:30Z","_mrn":"mrn:srv:entity:0681ad04-8e9c-4bf8-a495-0162bf65e4c0:entries/cf6d233a-a9dc-41e0-b7e5-3d96a20ae10f","_createdDate":"2024-07-15T12:13:30Z","jobTitle":"Backend Dev","hourlyRateForProjects":"80","costsByMonth":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","costsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"0","month":"2024-04"},{"costs":"0","month":"2024-05"},{"costs":"0","month":"2024-06"},{"costs":"0","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_updatedDate":"1723202174187","_definitionId":"d575547b-2778-4dcd-8551-146f70529e9d","_createdDate":"1721048454171"},"team":"mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/3d82f5f0-65f5-4b01-a028-4e44334ba94a","_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/fdc450ba-b43f-4010-b7b5-9f830d53732d","employmentStatus":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","employmentStatus":"Inaktiv","_updatedDate":"1723202181847","_definitionId":"610b6b9e-2b87-4d12-a7fb-8d268d0eb0d7","_createdDate":"1721045610692"},"utilisationRate":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-customer/bXJuPW1ybjpzcnY6ZW50aXR5OjA2ODFhZDA0LThlOWMtNGJmOC1hNDk1LTAxNjJiZjY1ZTRjMDplbnRyaWVzL2NmNmQyMzNhLWE5ZGMtNDFlMC1iN2U1LTNkOTZhMjBhZTEwZg==","lastname":"Max","workforceUtilisation":{"_updatedDate":"1723202186979","totalCostPerCustomer":"0.00","_createdDate":"1721145574527","utilisationRateOngoingQuarter":"0.0","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"0.0","timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"NaN","utilisationRateYearToDate":"0.0","utilisationRatePreviousQuarter":"0.0","_definitionId":"2a992875-4676-4dda-b916-3b9113eb13c5","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.00"},{"month":"June","utilisationRate":"0.00"}]},"name":"Mustermann Max","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/externals-potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5OjA2ODFhZDA0LThlOWMtNGJmOC1hNDk1LTAxNjJiZjY1ZTRjMDplbnRyaWVzL2NmNmQyMzNhLWE5ZGMtNDFlMC1iN2U1LTNkOTZhMjBhZTEwZg==","_archived":"false","salutation":"Herr","_id":"cf6d233a-a9dc-41e0-b7e5-3d96a20ae10f","email":"maximilian.weber+panda-test@micromerce.com","status":"active"}},
-    {"externals":{"birthday":"1997-07-12","firstname":"Jim","address":{"country":"DE","streetName":"Musterstraße","locality":"Frankfurt am Main"},"_updatedDate":"2024-07-28T11:10:19Z","_mrn":"mrn:srv:entity:0681ad04-8e9c-4bf8-a495-0162bf65e4c0:entries/b9a6c917-1534-4577-a9dd-ef7a4cfebebb","_createdDate":"2024-04-27T08:54:52Z","jobTitle":"Backend Dev","costsByMonth":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","costsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"0","month":"2024-04"},{"costs":"0","month":"2024-05"},{"costs":"0","month":"2024-06"},{"costs":"0","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_updatedDate":"1723202176463","_definitionId":"d575547b-2778-4dcd-8551-146f70529e9d","_createdDate":"1714212055093"},"team":"mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/c6041954-91a1-4af3-a91c-b143a591e456","_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a6aace64-770f-4b4a-8959-9ac04f4f2c81","employmentStatus":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","employmentStatus":"Inaktiv","_updatedDate":"1723202184559","_definitionId":"610b6b9e-2b87-4d12-a7fb-8d268d0eb0d7","_createdDate":"1714312453795"},"lastname":"Goldcoast","workforceUtilisation":{"_updatedDate":"1723202187177","totalCostPerCustomer":"240.00","_createdDate":"1721118017926","utilisationRateOngoingQuarter":"1.00","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"1.00","timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"1.00","utilisationRateYearToDate":"1.00","utilisationRatePreviousQuarter":"0.0","_definitionId":"2a992875-4676-4dda-b916-3b9113eb13c5","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"1.00"},{"month":"June","utilisationRate":"0.00"}]},"name":"Jim Goldcoast","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/externals-potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5OjA2ODFhZDA0LThlOWMtNGJmOC1hNDk1LTAxNjJiZjY1ZTRjMDplbnRyaWVzL2I5YTZjOTE3LTE1MzQtNDU3Ny1hOWRkLWVmN2E0Y2ZlYmViYg==","_archived":"false","_id":"b9a6c917-1534-4577-a9dd-ef7a4cfebebb","email":"jim.goldcoast.ext@micromerce.com","status":"active"}},
-    {"externals":{"birthday":"1980-10-14","firstname":"Sacher","address":{"country":"DE","streetName":"Große Reichenstraße","postalCode":"20457","locality":"Hamburg","houseNumber":"14"},"_updatedDate":"2024-07-10T11:02:48Z","_mrn":"mrn:srv:entity:0681ad04-8e9c-4bf8-a495-0162bf65e4c0:entries/d3f4b992-7234-45b2-ace0-b82cf7c58656","_createdDate":"2023-07-31T07:29:45Z","jobTitle":"Backend Dev","hourlyRateForProjects":"100","costsByMonth":{"_updatedDate":"1723202177173","_createdDate":"1713202714363","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","periods":[{"monthlySalary":"5918.181818181818","start":"2024-04-01","end":"2024-07-17","hourlyRate":"50.0","timeBudget":"420.0"}],"costsByMonth":[{"costs":"0","month":"2023-01"},{"costs":"0","month":"2023-02"},{"costs":"0","month":"2023-03"},{"costs":"0","month":"2023-04"},{"costs":"0","month":"2023-05"},{"costs":"0","month":"2023-06"},{"costs":"0","month":"2023-07"},{"costs":"0","month":"2023-08"},{"costs":"0","month":"2023-09"},{"costs":"0","month":"2023-10"},{"costs":"0","month":"2023-11"},{"costs":"0","month":"2023-12"},{"costs":"0","month":"2024-01"},{"costs":"0","month":"2024-02"},{"costs":"0","month":"2024-03"},{"costs":"5918","month":"2024-04"},{"costs":"5918","month":"2024-05"},{"costs":"5918","month":"2024-06"},{"costs":"3345","month":"2024-07"},{"costs":"0","month":"2024-08"},{"costs":"0","month":"2024-09"},{"costs":"0","month":"2024-10"},{"costs":"0","month":"2024-11"},{"costs":"0","month":"2024-12"},{"costs":"0","month":"2025-01"},{"costs":"0","month":"2025-02"},{"costs":"0","month":"2025-03"},{"costs":"0","month":"2025-04"},{"costs":"0","month":"2025-05"},{"costs":"0","month":"2025-06"},{"costs":"0","month":"2025-07"},{"costs":"0","month":"2025-08"}],"_definitionId":"d575547b-2778-4dcd-8551-146f70529e9d"},"team":"mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/3d82f5f0-65f5-4b01-a028-4e44334ba94a","_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a50976c6-fc81-4cc9-af8f-c30d08554307","employmentStatus":{"_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","employmentStatus":"Inaktiv","_updatedDate":"1723202184655","_definitionId":"610b6b9e-2b87-4d12-a7fb-8d268d0eb0d7","_createdDate":"1714312453775"},"utilisationRate":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-customer/bXJuPW1ybjpzcnY6ZW50aXR5OjA2ODFhZDA0LThlOWMtNGJmOC1hNDk1LTAxNjJiZjY1ZTRjMDplbnRyaWVzL2QzZjRiOTkyLTcyMzQtNDViMi1hY2UwLWI4MmNmN2M1ODY1Ng==","lastname":"Julius","workforceUtilisation":{"_updatedDate":"1723202186903","totalCostPerCustomer":"0.00","_createdDate":"1721145585996","utilisationRateOngoingQuarter":"0.0","_applicationId":"bbabea28-87a2-4439-bf36-53922115729c","monthlyCostDifference":"6400.0","utilisationRateLastTwelveMonths":"0.0","timeWorkedPreviousQuarter":"0.0","utilisationRateOverall":"NaN","utilisationRateYearToDate":"0.0","utilisationRatePreviousQuarter":"0.0","_definitionId":"2a992875-4676-4dda-b916-3b9113eb13c5","lastThreeMonthsIndividually":[{"month":"August","utilisationRate":"0.00"},{"month":"July","utilisationRate":"0.00"},{"month":"June","utilisationRate":"0.00"}]},"name":"Sacher Julius","potentialEarnings":"mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/externals-potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5OjA2ODFhZDA0LThlOWMtNGJmOC1hNDk1LTAxNjJiZjY1ZTRjMDplbnRyaWVzL2QzZjRiOTkyLTcyMzQtNDViMi1hY2UwLWI4MmNmN2M1ODY1Ng==","_archived":"false","salutation":"Herr","_id":"d3f4b992-7234-45b2-ace0-b82cf7c58656","email":"maximilian.weber+panda-test@micromerce.com","status":"active"}},
-    {"teams":{"_updatedDate":"2024-07-30T12:56:45Z","_mrn":"mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/774cb064-e0c6-448a-a338-4d50087469d1","_createdDate":"2024-07-30T12:56:45Z","name":"Dev","_archived":"false","_id":"774cb064-e0c6-448a-a338-4d50087469d1","_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/ae00e09d-6d53-4f98-a6be-f74b6dd635e2"}},
-    {"teams":{"_updatedDate":"2024-07-30T12:56:26Z","_mrn":"mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/aa59773b-4c4e-4304-82c8-274c33d0c8df","_createdDate":"2024-07-30T12:56:26Z","name":"Solution","_archived":"false","_id":"aa59773b-4c4e-4304-82c8-274c33d0c8df","_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/ae00e09d-6d53-4f98-a6be-f74b6dd635e2"}},
-    {"teams":{"_updatedDate":"2024-07-08T14:29:19Z","_mrn":"mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/3d82f5f0-65f5-4b01-a028-4e44334ba94a","_createdDate":"2024-07-08T14:29:19Z","name":"Test Team 2","_archived":"false","_id":"3d82f5f0-65f5-4b01-a028-4e44334ba94a","_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/f56454f7-c20e-42db-8cfa-4cb2b288eeb3","parentTeam":"mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/c6041954-91a1-4af3-a91c-b143a591e456"}},
-    {"teams":{"_updatedDate":"2024-07-08T14:29:11Z","_mrn":"mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/c6041954-91a1-4af3-a91c-b143a591e456","_createdDate":"2024-07-08T14:29:11Z","name":"Test Team","_archived":"false","_id":"c6041954-91a1-4af3-a91c-b143a591e456","_createdBy":"mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/f56454f7-c20e-42db-8cfa-4cb2b288eeb3"}}
+  {
+    "employees": {
+      "birthday": "2000-05-25",
+      "firstname": "Justus",
+      "_mrn": "mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/cd1eb663-87d5-4ce3-8e72-a8201ebdb1e2",
+      "_createdDate": "2024-07-16T16:04:38Z",
+      "jobTitle": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==",
+      "hourlyRateForProjects": "20",
+      "costsByMonth": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "potentialEarningsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "0", "month": "2024-04" },
+          { "costs": "0", "month": "2024-05" },
+          { "costs": "0", "month": "2024-06" },
+          { "costs": "0", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_updatedDate": "1723202172448",
+        "_definitionId": "6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5",
+        "_createdDate": "1721145882092"
+      },
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/f56454f7-c20e-42db-8cfa-4cb2b288eeb3",
+      "usedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==",
+      "_archived": "false",
+      "statusAggregation": {
+        "monthlySalary": "null",
+        "_updatedDate": "1723202164134",
+        "yearlyVacationDays": "null",
+        "_createdDate": "1721145879322",
+        "jobTitle": "null",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "weeklyWorkingHours": "null",
+        "jobType": "null",
+        "_definitionId": "1da52573-107e-4c2c-b349-d59f791f3d75",
+        "status": "Inaktiv"
+      },
+      "jobType": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==",
+      "address": {
+        "country": "AS",
+        "streetName": "asdasda",
+        "locality": "Giieee"
+      },
+      "hoursPerWeek": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==",
+      "_updatedDate": "2024-07-28T11:03:59Z",
+      "team": "mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/3d82f5f0-65f5-4b01-a028-4e44334ba94a",
+      "targetWorkingHours": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==",
+      "lastname": "Peter",
+      "holidayPerYear": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202184886",
+        "totalCostPerCustomer": "120.00",
+        "_createdDate": "1721145879688",
+        "utilisationRateOngoingQuarter": "0.67",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "3200.0",
+        "utilisationRateLastTwelveMonths": "0.67",
+        "quarterEarnings": [
+          {
+            "earnings": "0.0",
+            "start": "2024-01-01",
+            "name": "Q1",
+            "end": "2024-03-31"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-04-01",
+            "name": "Q2",
+            "end": "2024-06-30"
+          },
+          {
+            "earnings": "120.0",
+            "start": "2024-07-01",
+            "name": "Q3",
+            "end": "2024-09-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-10-01",
+            "name": "Q4",
+            "end": "2024-12-31"
+          }
+        ],
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "0.67",
+        "utilisationRateYearToDate": "0.67",
+        "utilisationRatePreviousQuarter": "0.00",
+        "_definitionId": "d0448e0f-4225-4196-bd45-8b70730bd397",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.67" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "name": "Justus Peter",
+      "earnedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2NkMWViNjYzLTg3ZDUtNGNlMy04ZTcyLWE4MjAxZWJkYjFlMg==",
+      "_id": "cd1eb663-87d5-4ce3-8e72-a8201ebdb1e2",
+      "individualTicketDuration": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz",
+      "searchValue": "justus peter mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2nkmwvinjyzltg3zdutngnlmy04ztcylwe4mjaxzwjkyjflmg==",
+      "status": "active"
+    }
+  },
+  {
+    "employees": {
+      "birthday": "1992-05-30",
+      "firstname": "Lustig",
+      "_mrn": "mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/c50d2396-97de-48dd-a0c0-c4709e869f5b",
+      "_createdDate": "2024-06-06T08:23:22Z",
+      "jobTitle": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==",
+      "hourlyRateForProjects": "5",
+      "costsByMonth": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "potentialEarningsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "0", "month": "2024-04" },
+          { "costs": "0", "month": "2024-05" },
+          { "costs": "0", "month": "2024-06" },
+          { "costs": "0", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_updatedDate": "1723202172555",
+        "_definitionId": "6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5",
+        "_createdDate": "1717662205927"
+      },
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/fdc450ba-b43f-4010-b7b5-9f830d53732d",
+      "authUser": "mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/21406cd2-c9fd-41c2-a8b1-ff68dfc2f0d3",
+      "usedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==",
+      "_archived": "false",
+      "statusAggregation": {
+        "monthlySalary": "null",
+        "_updatedDate": "1723202164312",
+        "yearlyVacationDays": "null",
+        "_createdDate": "1717662202719",
+        "jobTitle": "null",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "weeklyWorkingHours": "null",
+        "jobType": "null",
+        "_definitionId": "1da52573-107e-4c2c-b349-d59f791f3d75",
+        "status": "Inaktiv"
+      },
+      "jobType": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==",
+      "address": {
+        "country": "DE",
+        "streetName": "Test",
+        "postalCode": "12345",
+        "locality": "Berlin",
+        "houseNumber": "123"
+      },
+      "hoursPerWeek": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==",
+      "_updatedDate": "2024-07-28T11:04:32Z",
+      "targetWorkingHours": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==",
+      "lastname": "Sophie",
+      "holidayPerYear": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202185821",
+        "totalCostPerCustomer": "0.00",
+        "_createdDate": "1721125125055",
+        "utilisationRateOngoingQuarter": "0.00",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "0.00",
+        "quarterEarnings": [
+          {
+            "earnings": "0.0",
+            "start": "2024-01-01",
+            "name": "Q1",
+            "end": "2024-03-31"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-04-01",
+            "name": "Q2",
+            "end": "2024-06-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-07-01",
+            "name": "Q3",
+            "end": "2024-09-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-10-01",
+            "name": "Q4",
+            "end": "2024-12-31"
+          }
+        ],
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "0.00",
+        "utilisationRateYearToDate": "0.00",
+        "utilisationRatePreviousQuarter": "0.00",
+        "_definitionId": "d0448e0f-4225-4196-bd45-8b70730bd397",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "websiteInformation": { "secret": "zehnteapril3005" },
+      "name": "Lustig Sophie",
+      "salutation": "Herr",
+      "earnedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M1MGQyMzk2LTk3ZGUtNDhkZC1hMGMwLWM0NzA5ZTg2OWY1Yg==",
+      "_id": "c50d2396-97de-48dd-a0c0-c4709e869f5b",
+      "individualTicketDuration": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz",
+      "searchValue": "lustig sophie mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2m1mgqymzk2ltk3zgutndhkzc1hmgmwlwm0nza5ztg2owy1yg==",
+      "status": "active"
+    }
+  },
+  {
+    "employees": {
+      "birthday": "2024-05-11",
+      "firstname": "Neumann",
+      "documents": [
+        {
+          "image": "https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/59434b7b-ed08-47bd-88a3-ae634083f087/Document.pdf"
+        }
+      ],
+      "_mrn": "mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/bcf37ecd-36f4-4a8d-a732-5c833de88d2c",
+      "_createdDate": "2024-05-09T14:02:09Z",
+      "jobTitle": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==",
+      "costsByMonth": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "potentialEarningsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "0", "month": "2024-04" },
+          { "costs": "0", "month": "2024-05" },
+          { "costs": "0", "month": "2024-06" },
+          { "costs": "0", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_updatedDate": "1723202172656",
+        "_definitionId": "6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5",
+        "_createdDate": "1715263333140"
+      },
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/afd9447f-b750-4b1c-9ade-02956f90950e",
+      "authUser": "mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/273322a6-d830-4758-b140-5f0b9bee938f",
+      "usedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==",
+      "_archived": "false",
+      "statusAggregation": {
+        "monthlySalary": "null",
+        "_updatedDate": "1723202164421",
+        "yearlyVacationDays": "null",
+        "_createdDate": "1715263329918",
+        "jobTitle": "null",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "weeklyWorkingHours": "null",
+        "jobType": "null",
+        "_definitionId": "1da52573-107e-4c2c-b349-d59f791f3d75",
+        "status": "Inaktiv"
+      },
+      "jobType": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==",
+      "email": "amelie.neumann.fake@micromerce.com",
+      "address": {
+        "country": "IN",
+        "streetName": "Street 1",
+        "locality": "Kerala"
+      },
+      "hoursPerWeek": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==",
+      "_updatedDate": "2024-07-28T11:05:02Z",
+      "photo": "https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/d8e87051-32bd-4a8c-9a48-94d5bae0bf0b/beautiful-hologram-water-color-frame-png_119551.jpg",
+      "targetWorkingHours": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==",
+      "lastname": "Amelie",
+      "holidayPerYear": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==",
+      "slackId": "D06VD0JAPKM",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202185722",
+        "totalCostPerCustomer": "0.00",
+        "_createdDate": "1721125127119",
+        "utilisationRateOngoingQuarter": "0.00",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "0.00",
+        "quarterEarnings": [
+          {
+            "earnings": "0.0",
+            "start": "2024-01-01",
+            "name": "Q1",
+            "end": "2024-03-31"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-04-01",
+            "name": "Q2",
+            "end": "2024-06-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-07-01",
+            "name": "Q3",
+            "end": "2024-09-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-10-01",
+            "name": "Q4",
+            "end": "2024-12-31"
+          }
+        ],
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "0.00",
+        "utilisationRateYearToDate": "0.00",
+        "utilisationRatePreviousQuarter": "0.00",
+        "_definitionId": "d0448e0f-4225-4196-bd45-8b70730bd397",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "name": "Neumann Amelie",
+      "salutation": "Frau",
+      "earnedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2JjZjM3ZWNkLTM2ZjQtNGE4ZC1hNzMyLTVjODMzZGU4OGQyYw==",
+      "_id": "bcf37ecd-36f4-4a8d-a732-5c833de88d2c",
+      "individualTicketDuration": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz",
+      "searchValue": "neumann amelie mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2jjzjm3zwnkltm2zjqtnge4zc1hnzmyltvjodmzzgu4ogqyyw==",
+      "status": "active"
+    }
+  },
+  {
+    "employees": {
+      "birthday": "2024-05-11",
+      "firstname": "Groß",
+      "documents": [
+        {
+          "image": "https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/59434b7b-ed08-47bd-88a3-ae634083f087/Document.pdf"
+        }
+      ],
+      "_mrn": "mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/5bddc396-6343-4451-911b-e91837e42b97",
+      "_createdDate": "2024-05-07T09:55:45Z",
+      "jobTitle": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==",
+      "costsByMonth": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "potentialEarningsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "0", "month": "2024-04" },
+          { "costs": "0", "month": "2024-05" },
+          { "costs": "0", "month": "2024-06" },
+          { "costs": "0", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_updatedDate": "1723202172745",
+        "_definitionId": "6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5",
+        "_createdDate": "1715075749406"
+      },
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/ae00e09d-6d53-4f98-a6be-f74b6dd635e2",
+      "authUser": "mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/273322a6-d830-4758-b140-5f0b9bee938f",
+      "usedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==",
+      "_archived": "false",
+      "statusAggregation": {
+        "monthlySalary": "null",
+        "_updatedDate": "1723202164591",
+        "yearlyVacationDays": "null",
+        "_createdDate": "1715075747290",
+        "jobTitle": "null",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "weeklyWorkingHours": "null",
+        "jobType": "null",
+        "_definitionId": "1da52573-107e-4c2c-b349-d59f791f3d75",
+        "status": "Inaktiv"
+      },
+      "jobType": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==",
+      "email": "julius@micromerce.com",
+      "address": {
+        "country": "IN",
+        "streetName": "Street 1",
+        "locality": "Kerala"
+      },
+      "hoursPerWeek": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==",
+      "_updatedDate": "2024-07-28T11:05:35Z",
+      "photo": "https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/d8e87051-32bd-4a8c-9a48-94d5bae0bf0b/beautiful-hologram-water-color-frame-png_119551.jpg",
+      "targetWorkingHours": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==",
+      "lastname": "Julius",
+      "holidayPerYear": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==",
+      "slackId": "D06VD0JAPKM",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202185600",
+        "totalCostPerCustomer": "0.00",
+        "_createdDate": "1721125129181",
+        "utilisationRateOngoingQuarter": "0.00",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "0.00",
+        "quarterEarnings": [
+          {
+            "earnings": "0.0",
+            "start": "2024-01-01",
+            "name": "Q1",
+            "end": "2024-03-31"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-04-01",
+            "name": "Q2",
+            "end": "2024-06-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-07-01",
+            "name": "Q3",
+            "end": "2024-09-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-10-01",
+            "name": "Q4",
+            "end": "2024-12-31"
+          }
+        ],
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "0.00",
+        "utilisationRateYearToDate": "0.00",
+        "utilisationRatePreviousQuarter": "0.00",
+        "_definitionId": "d0448e0f-4225-4196-bd45-8b70730bd397",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "name": "Groß Julius",
+      "salutation": "Frau",
+      "earnedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzViZGRjMzk2LTYzNDMtNDQ1MS05MTFiLWU5MTgzN2U0MmI5Nw==",
+      "_id": "5bddc396-6343-4451-911b-e91837e42b97",
+      "individualTicketDuration": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz",
+      "searchValue": "groß julius mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzlzvizgrjmzk2ltyzndmtndq1ms05mtfilwu5mtgzn2u0mmi5nw==",
+      "status": "active"
+    }
+  },
+  {
+    "employees": {
+      "birthday": "2024-04-10",
+      "firstname": "Bredolph",
+      "_mrn": "mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/42c0434b-497d-4848-bc03-9a2a2ddb531f",
+      "_createdDate": "2024-04-09T09:11:34Z",
+      "jobTitle": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "costsByMonth": {
+        "_updatedDate": "1723202173498",
+        "_createdDate": "1713173714530",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "periods": [
+          {
+            "monthlySalary": "3000",
+            "start": "2024-04-19",
+            "end": "2024-05-23"
+          }
+        ],
+        "potentialEarningsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "1342", "month": "2024-04" },
+          { "costs": "2567", "month": "2024-05" },
+          { "costs": "0", "month": "2024-06" },
+          { "costs": "0", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_definitionId": "6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5"
+      },
+      "utilisationRateLastTwelveMonths": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-employee/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/f677cb20-2cb0-465e-991c-ff6a85bcf5ef",
+      "utilisationRate": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-customer/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "existingPayrollCount": "6",
+      "usedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "workforceUtilisation2": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-employee/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "_archived": "false",
+      "statusAggregation": {
+        "monthlySalary": "3000",
+        "_updatedDate": "1723202164692",
+        "yearlyVacationDays": "30",
+        "_createdDate": "1712653894771",
+        "jobTitle": "QA Consultant",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "weeklyWorkingHours": "40",
+        "jobType": "vollzeit",
+        "_definitionId": "1da52573-107e-4c2c-b349-d59f791f3d75",
+        "status": "Inaktiv"
+      },
+      "jobType": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "hoursPerWeek": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "address": {
+        "country": "DE",
+        "streetName": "Horkelbräuscherstraße",
+        "locality": "Gronkelbecken an der Leine"
+      },
+      "_updatedDate": "2024-06-07T15:32:36Z",
+      "sickNotesPreviousAmount": "2",
+      "targetWorkingHours": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "lastname": "Hanseljauch",
+      "holidayPerYear": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202185341",
+        "totalCostPerCustomer": "0.00",
+        "_createdDate": "1721125131246",
+        "utilisationRateOngoingQuarter": "0.00",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "0.00",
+        "quarterEarnings": [
+          {
+            "earnings": "0.0",
+            "start": "2024-01-01",
+            "name": "Q1",
+            "end": "2024-03-31"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-04-01",
+            "name": "Q2",
+            "end": "2024-06-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-07-01",
+            "name": "Q3",
+            "end": "2024-09-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-10-01",
+            "name": "Q4",
+            "end": "2024-12-31"
+          }
+        ],
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "0.00",
+        "utilisationRateYearToDate": "0.00",
+        "utilisationRatePreviousQuarter": "0.00",
+        "_definitionId": "d0448e0f-4225-4196-bd45-8b70730bd397",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "name": "Bredolph Hanseljauch",
+      "earnedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "_id": "42c0434b-497d-4848-bc03-9a2a2ddb531f",
+      "searchValue": "bredolph hanseljauch mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzlzqyyza0mzriltq5n2qtndg0oc1iyzazltlhmmeyzgrintmxzg==",
+      "bookedTimeOverview": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/booked-time-overview/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzQyYzA0MzRiLTQ5N2QtNDg0OC1iYzAzLTlhMmEyZGRiNTMxZg==",
+      "individualTicketDuration": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz",
+      "status": "active"
+    }
+  },
+  {
+    "employees": {
+      "birthday": "2024-04-24",
+      "firstname": "World",
+      "_mrn": "mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/ae2fbd9a-dbe2-4f5f-95a3-645099f2577f",
+      "_createdDate": "2024-04-09T08:56:13Z",
+      "jobTitle": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "costsByMonth": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "potentialEarningsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "0", "month": "2024-04" },
+          { "costs": "0", "month": "2024-05" },
+          { "costs": "0", "month": "2024-06" },
+          { "costs": "0", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_updatedDate": "1723202173622",
+        "_definitionId": "6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5",
+        "_createdDate": "1713173108444"
+      },
+      "utilisationRateLastTwelveMonths": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-employee/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/f677cb20-2cb0-465e-991c-ff6a85bcf5ef",
+      "utilisationRate": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-customer/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "usedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "workforceUtilisation2": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-employee/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "_archived": "false",
+      "statusAggregation": {
+        "monthlySalary": "null",
+        "_updatedDate": "1723202164800",
+        "yearlyVacationDays": "null",
+        "_createdDate": "1712652973623",
+        "jobTitle": "null",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "weeklyWorkingHours": "null",
+        "jobType": "null",
+        "_definitionId": "1da52573-107e-4c2c-b349-d59f791f3d75",
+        "status": "Inaktiv"
+      },
+      "jobType": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "hoursPerWeek": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "address": {
+        "country": "DE",
+        "streetName": "Hausstraße",
+        "locality": "Zweihügel"
+      },
+      "_updatedDate": "2024-04-27T10:24:53Z",
+      "sickNotesPreviousAmount": "2",
+      "targetWorkingHours": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "lastname": "Hello",
+      "holidayPerYear": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202185240",
+        "totalCostPerCustomer": "0.00",
+        "_createdDate": "1721125133310",
+        "utilisationRateOngoingQuarter": "0.00",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "0.00",
+        "quarterEarnings": [
+          {
+            "earnings": "0.0",
+            "start": "2024-01-01",
+            "name": "Q1",
+            "end": "2024-03-31"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-04-01",
+            "name": "Q2",
+            "end": "2024-06-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-07-01",
+            "name": "Q3",
+            "end": "2024-09-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-10-01",
+            "name": "Q4",
+            "end": "2024-12-31"
+          }
+        ],
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "0.00",
+        "utilisationRateYearToDate": "0.00",
+        "utilisationRatePreviousQuarter": "0.00",
+        "_definitionId": "d0448e0f-4225-4196-bd45-8b70730bd397",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "name": "World Hello",
+      "earnedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "_id": "ae2fbd9a-dbe2-4f5f-95a3-645099f2577f",
+      "searchValue": "world hello mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2flmmzizdlhlwriztitngy1zi05nwezlty0nta5owyyntc3zg==",
+      "bookedTimeOverview": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/booked-time-overview/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2FlMmZiZDlhLWRiZTItNGY1Zi05NWEzLTY0NTA5OWYyNTc3Zg==",
+      "individualTicketDuration": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz",
+      "status": "active"
+    }
+  },
+  {
+    "employees": {
+      "birthday": "2023-01-01",
+      "firstname": "Musterperson",
+      "_mrn": "mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/c917942d-737e-4b8d-a3b2-6a82c1c3d88a",
+      "_createdDate": "2024-01-03T15:55:23Z",
+      "jobTitle": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==",
+      "hourlyRateForProjects": "30",
+      "costsByMonth": {
+        "_updatedDate": "1723202173348",
+        "_createdDate": "1713202691098",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "periods": [
+          {
+            "monthlySalary": "2000",
+            "start": "2023-04-01",
+            "end": "2023-10-14"
+          },
+          {
+            "monthlySalary": "1000",
+            "start": "2023-10-15",
+            "end": "2024-01-31"
+          },
+          { "monthlySalary": "2000", "start": "2024-02-01", "end": "null" }
+        ],
+        "potentialEarningsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "2460", "month": "2023-04" },
+          { "costs": "2460", "month": "2023-05" },
+          { "costs": "2460", "month": "2023-06" },
+          { "costs": "2460", "month": "2023-07" },
+          { "costs": "2460", "month": "2023-08" },
+          { "costs": "2460", "month": "2023-09" },
+          { "costs": "1789", "month": "2023-10" },
+          { "costs": "1230", "month": "2023-11" },
+          { "costs": "1230", "month": "2023-12" },
+          { "costs": "1177", "month": "2024-01" },
+          { "costs": "2460", "month": "2024-02" },
+          { "costs": "2460", "month": "2024-03" },
+          { "costs": "2460", "month": "2024-04" },
+          { "costs": "2460", "month": "2024-05" },
+          { "costs": "2460", "month": "2024-06" },
+          { "costs": "2460", "month": "2024-07" },
+          { "costs": "2460", "month": "2024-08" },
+          { "costs": "2460", "month": "2024-09" },
+          { "costs": "2460", "month": "2024-10" },
+          { "costs": "2460", "month": "2024-11" },
+          { "costs": "2460", "month": "2024-12" },
+          { "costs": "2460", "month": "2025-01" },
+          { "costs": "2460", "month": "2025-02" },
+          { "costs": "2460", "month": "2025-03" },
+          { "costs": "2460", "month": "2025-04" },
+          { "costs": "2460", "month": "2025-05" },
+          { "costs": "2460", "month": "2025-06" },
+          { "costs": "2460", "month": "2025-07" },
+          { "costs": "2460", "month": "2025-08" }
+        ],
+        "_definitionId": "6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5"
+      },
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a50976c6-fc81-4cc9-af8f-c30d08554307",
+      "usedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==",
+      "lastTimelogDailyReminderSentDate": "2024-02-14",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==",
+      "_archived": "false",
+      "statusAggregation": {
+        "monthlySalary": "2000",
+        "_updatedDate": "1723202165420",
+        "yearlyVacationDays": "30",
+        "_createdDate": "1704827393774",
+        "jobTitle": "Technical Customer Success Manager",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "weeklyWorkingHours": "40",
+        "jobType": "vollzeit",
+        "_definitionId": "1da52573-107e-4c2c-b349-d59f791f3d75",
+        "status": "Aktiv"
+      },
+      "jobType": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==",
+      "email": "maximilian.weber+for-termination@micromerce.com",
+      "address": {
+        "country": "AT",
+        "streetName": "Große Karottengasse",
+        "postalCode": "1020",
+        "locality": "Wien",
+        "houseNumber": "14"
+      },
+      "hoursPerWeek": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==",
+      "_updatedDate": "2024-07-30T12:59:00Z",
+      "sickNotesPreviousAmount": "3",
+      "photo": "https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/ba8f8f4a-7a0c-48d2-8fec-2fcac94b1386/Florian.png",
+      "team": "mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/774cb064-e0c6-448a-a338-4d50087469d1",
+      "targetWorkingHours": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==",
+      "lastname": "Enja",
+      "holidayPerYear": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202186776",
+        "totalCostPerCustomer": "45.00",
+        "_createdDate": "1721117704495",
+        "utilisationRateOngoingQuarter": "0.00",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "4800.0",
+        "utilisationRateLastTwelveMonths": "1.00",
+        "quarterEarnings": [
+          {
+            "earnings": "0.0",
+            "start": "2024-01-01",
+            "name": "Q1",
+            "end": "2024-03-31"
+          },
+          {
+            "earnings": "45.0",
+            "start": "2024-04-01",
+            "name": "Q2",
+            "end": "2024-06-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-07-01",
+            "name": "Q3",
+            "end": "2024-09-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-10-01",
+            "name": "Q4",
+            "end": "2024-12-31"
+          }
+        ],
+        "timeWorkedPreviousQuarter": "1.5",
+        "utilisationRateOverall": "1.00",
+        "utilisationRateYearToDate": "1.00",
+        "utilisationRatePreviousQuarter": "1.00",
+        "_definitionId": "d0448e0f-4225-4196-bd45-8b70730bd397",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "websiteInformation": {
+        "hubspotUrl": "http://awd.de",
+        "secret": "12345"
+      },
+      "name": "Musterperson Enja",
+      "earnedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2M5MTc5NDJkLTczN2UtNGI4ZC1hM2IyLTZhODJjMWMzZDg4YQ==",
+      "_id": "c917942d-737e-4b8d-a3b2-6a82c1c3d88a",
+      "searchValue": "musterperson enja mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2m5mtc5ndjkltczn2utngi4zc1hm2iyltzhodjjmwmzzdg4yq==",
+      "status": "active"
+    }
+  },
+  {
+    "employees": {
+      "birthday": "1999-01-31",
+      "firstname": "Grünelinde",
+      "_mrn": "mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/6c072f15-64f9-4d79-b218-f606c00c98d8",
+      "_createdDate": "2023-05-16T13:20:20Z",
+      "jobTitle": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==",
+      "costsByMonth": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "potentialEarningsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "0", "month": "2024-04" },
+          { "costs": "0", "month": "2024-05" },
+          { "costs": "0", "month": "2024-06" },
+          { "costs": "0", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_updatedDate": "1723202173204",
+        "_definitionId": "6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5",
+        "_createdDate": "1713202693396"
+      },
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a50976c6-fc81-4cc9-af8f-c30d08554307",
+      "authUser": "mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/51994c43-d7ab-4936-81d4-51426896173e",
+      "usedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==",
+      "_archived": "false",
+      "statusAggregation": {
+        "monthlySalary": "null",
+        "_updatedDate": "1723202165309",
+        "yearlyVacationDays": "null",
+        "_createdDate": "1704827393801",
+        "jobTitle": "null",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "weeklyWorkingHours": "null",
+        "jobType": "null",
+        "_definitionId": "1da52573-107e-4c2c-b349-d59f791f3d75",
+        "status": "Inaktiv"
+      },
+      "jobType": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==",
+      "email": "charlotte.gruenelinde@micromerce.com",
+      "address": {
+        "country": "AL",
+        "streetName": "Test",
+        "postalCode": "12345",
+        "locality": "Hamburg",
+        "houseNumber": "1"
+      },
+      "hoursPerWeek": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==",
+      "_updatedDate": "2024-07-28T11:07:55Z",
+      "fallbackJobTitle": "Frontend Entwickler",
+      "targetWorkingHours": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==",
+      "lastname": "Charlotte",
+      "holidayPerYear": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==",
+      "phone": "12345",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202186576",
+        "totalCostPerCustomer": "210.00",
+        "_createdDate": "1721117793866",
+        "utilisationRateOngoingQuarter": "0.00",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "0.10",
+        "quarterEarnings": [
+          {
+            "earnings": "0.0",
+            "start": "2024-01-01",
+            "name": "Q1",
+            "end": "2024-03-31"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-04-01",
+            "name": "Q2",
+            "end": "2024-06-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-07-01",
+            "name": "Q3",
+            "end": "2024-09-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-10-01",
+            "name": "Q4",
+            "end": "2024-12-31"
+          }
+        ],
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "0.14",
+        "utilisationRateYearToDate": "0.00",
+        "utilisationRatePreviousQuarter": "0.00",
+        "_definitionId": "d0448e0f-4225-4196-bd45-8b70730bd397",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "websiteInformation": {
+        "hubspotUrl": "https://micromerce-solutions.com/meetings/robert-bernhardt",
+        "secret": "1234232134234234"
+      },
+      "name": "Grünelinde Charlotte",
+      "salutation": "Herr",
+      "earnedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzZjMDcyZjE1LTY0ZjktNGQ3OS1iMjE4LWY2MDZjMDBjOThkOA==",
+      "_id": "6c072f15-64f9-4d79-b218-f606c00c98d8",
+      "individualTicketDuration": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz",
+      "searchValue": "grünelinde charlotte mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzlzzjmdcyzje1lty0zjktngq3os1imje4lwy2mdzjmdbjothkoa==",
+      "status": "active"
+    }
+  },
+  {
+    "employees": {
+      "birthday": "1985-12-28",
+      "firstname": "Johnson",
+      "_mrn": "mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/fd5c4fd7-08dd-4bf9-898e-cc1e275e144d",
+      "_createdDate": "2023-04-11T09:19:40Z",
+      "jobTitle": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==",
+      "costsByMonth": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "potentialEarningsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "0", "month": "2024-04" },
+          { "costs": "0", "month": "2024-05" },
+          { "costs": "0", "month": "2024-06" },
+          { "costs": "0", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_updatedDate": "1723202173093",
+        "_definitionId": "6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5",
+        "_createdDate": "1713202697577"
+      },
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a50976c6-fc81-4cc9-af8f-c30d08554307",
+      "authUser": "mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/f120c511-abbf-4ee2-a682-11ce9eb2df67",
+      "usedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==",
+      "_archived": "false",
+      "statusAggregation": {
+        "monthlySalary": "null",
+        "_updatedDate": "1723202164918",
+        "yearlyVacationDays": "null",
+        "_createdDate": "1704827393844",
+        "jobTitle": "null",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "weeklyWorkingHours": "null",
+        "jobType": "null",
+        "_definitionId": "1da52573-107e-4c2c-b349-d59f791f3d75",
+        "status": "Inaktiv"
+      },
+      "jobType": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==",
+      "email": "richard.johnson@micromerce.com",
+      "address": {
+        "country": "DE",
+        "streetName": "Sandweg",
+        "postalCode": "34225",
+        "locality": "Baunatal",
+        "houseNumber": "3"
+      },
+      "hoursPerWeek": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==",
+      "_updatedDate": "2024-07-28T11:02:41Z",
+      "photo": "https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/bfb418ab-d198-452e-ad2b-23c655e5293e/avatar_02.png",
+      "targetWorkingHours": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==",
+      "lastname": "Richard",
+      "holidayPerYear": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202186071",
+        "totalCostPerCustomer": "360.00",
+        "_createdDate": "1721118449814",
+        "utilisationRateOngoingQuarter": "0.00",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "1.00",
+        "quarterEarnings": [
+          {
+            "earnings": "0.0",
+            "start": "2024-01-01",
+            "name": "Q1",
+            "end": "2024-03-31"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-04-01",
+            "name": "Q2",
+            "end": "2024-06-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-07-01",
+            "name": "Q3",
+            "end": "2024-09-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-10-01",
+            "name": "Q4",
+            "end": "2024-12-31"
+          }
+        ],
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "1.00",
+        "utilisationRateYearToDate": "0.00",
+        "utilisationRatePreviousQuarter": "0.00",
+        "_definitionId": "d0448e0f-4225-4196-bd45-8b70730bd397",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "name": "Johnson Richard",
+      "salutation": "Herr",
+      "earnedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzL2ZkNWM0ZmQ3LTA4ZGQtNGJmOS04OThlLWNjMWUyNzVlMTQ0ZA==",
+      "_id": "fd5c4fd7-08dd-4bf9-898e-cc1e275e144d",
+      "individualTicketDuration": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz",
+      "searchValue": "johnson richard mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzl2zknwm0zmq3lta4zgqtngjmos04othllwnjmwuynzvlmtq0za==",
+      "status": "active"
+    }
+  },
+  {
+    "employees": {
+      "birthday": "2022-01-01",
+      "firstname": "Max",
+      "_mrn": "mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/357fca21-8011-4420-b130-dec7748fa7c2",
+      "_createdDate": "2023-01-27T11:08:44Z",
+      "jobTitle": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==",
+      "costsByMonth": {
+        "_updatedDate": "1723202172987",
+        "_createdDate": "1713202701745",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "periods": [
+          { "monthlySalary": "3000", "start": "2024-02-01", "end": "null" }
+        ],
+        "potentialEarningsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "3690", "month": "2024-02" },
+          { "costs": "3690", "month": "2024-03" },
+          { "costs": "3690", "month": "2024-04" },
+          { "costs": "3690", "month": "2024-05" },
+          { "costs": "3690", "month": "2024-06" },
+          { "costs": "3690", "month": "2024-07" },
+          { "costs": "3690", "month": "2024-08" },
+          { "costs": "3690", "month": "2024-09" },
+          { "costs": "3690", "month": "2024-10" },
+          { "costs": "3690", "month": "2024-11" },
+          { "costs": "3690", "month": "2024-12" },
+          { "costs": "3690", "month": "2025-01" },
+          { "costs": "3690", "month": "2025-02" },
+          { "costs": "3690", "month": "2025-03" },
+          { "costs": "3690", "month": "2025-04" },
+          { "costs": "3690", "month": "2025-05" },
+          { "costs": "3690", "month": "2025-06" },
+          { "costs": "3690", "month": "2025-07" },
+          { "costs": "3690", "month": "2025-08" }
+        ],
+        "_definitionId": "6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5"
+      },
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a50976c6-fc81-4cc9-af8f-c30d08554307",
+      "authUser": "mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/273322a6-d830-4758-b140-5f0b9bee938f",
+      "usedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==",
+      "lastTimelogDailyReminderSentDate": "2024-08-09",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==",
+      "_archived": "false",
+      "statusAggregation": {
+        "monthlySalary": "3000",
+        "_updatedDate": "1723202165202",
+        "yearlyVacationDays": "30",
+        "_createdDate": "1704827393818",
+        "jobTitle": "Entwickler",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "weeklyWorkingHours": "40",
+        "jobType": "vollzeit",
+        "_definitionId": "1da52573-107e-4c2c-b349-d59f791f3d75",
+        "status": "Aktiv"
+      },
+      "jobType": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==",
+      "address": {
+        "country": "DE",
+        "streetName": "Musterstraße",
+        "postalCode": "20457",
+        "locality": "Hamburg",
+        "houseNumber": "8"
+      },
+      "hoursPerWeek": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==",
+      "_updatedDate": "2024-08-09T11:45:52Z",
+      "photo": "https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/c966c89b-e1d6-4bd7-9270-ea3c55ac4cb8/Eva%20Avatar.png",
+      "team": "mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/aa59773b-4c4e-4304-82c8-274c33d0c8df",
+      "targetWorkingHours": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==",
+      "lastname": "Mustermann",
+      "holidayPerYear": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==",
+      "slackId": "U065LFQ2JCU",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202186285",
+        "totalCostPerCustomer": "1480.00",
+        "_createdDate": "1721118293236",
+        "utilisationRateOngoingQuarter": "1.00",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "1.00",
+        "quarterEarnings": [
+          {
+            "earnings": "720.0",
+            "start": "2024-01-01",
+            "name": "Q1",
+            "end": "2024-03-31"
+          },
+          {
+            "earnings": "360.0",
+            "start": "2024-04-01",
+            "name": "Q2",
+            "end": "2024-06-30"
+          },
+          {
+            "earnings": "280.0",
+            "start": "2024-07-01",
+            "name": "Q3",
+            "end": "2024-09-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-10-01",
+            "name": "Q4",
+            "end": "2024-12-31"
+          }
+        ],
+        "timeWorkedPreviousQuarter": "9.0",
+        "utilisationRateOverall": "1.00",
+        "utilisationRateYearToDate": "1.00",
+        "utilisationRatePreviousQuarter": "1.00",
+        "_definitionId": "d0448e0f-4225-4196-bd45-8b70730bd397",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "1.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "name": "Max Mustermann",
+      "earnedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzM1N2ZjYTIxLTgwMTEtNDQyMC1iMTMwLWRlYzc3NDhmYTdjMg==",
+      "_id": "357fca21-8011-4420-b130-dec7748fa7c2",
+      "searchValue": "max mustermann mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzlzm1n2zjytixltgwmtetndqymc1imtmwlwrlyzc3ndhmytdjmg==",
+      "status": "active"
+    }
+  },
+  {
+    "employees": {
+      "birthday": "1983-01-29",
+      "firstname": "Rom",
+      "_mrn": "mrn:srv:entity:979e43d0-1008-4169-98b9-834432ad94c3:entries/9946a5c7-0845-4575-86e0-32bf3e746ae2",
+      "_createdDate": "2021-05-16T10:00:02Z",
+      "jobTitle": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==",
+      "costsByMonth": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "potentialEarningsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "0", "month": "2024-04" },
+          { "costs": "0", "month": "2024-05" },
+          { "costs": "0", "month": "2024-06" },
+          { "costs": "0", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_updatedDate": "1723202172847",
+        "_definitionId": "6b5aa8c0-1cf0-40de-8f6b-aea330a28fe5",
+        "_createdDate": "1713202705920"
+      },
+      "authUser": "mrn:srv:auth:4a1ead93-422a-469f-801e-bef7aa39fdb9:users/9ca3299c-3286-46f7-855d-7a970bf2c624",
+      "usedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/used-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==",
+      "_archived": "false",
+      "statusAggregation": {
+        "monthlySalary": "null",
+        "_updatedDate": "1723202165080",
+        "yearlyVacationDays": "null",
+        "_createdDate": "1704827393822",
+        "jobTitle": "null",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "weeklyWorkingHours": "null",
+        "jobType": "null",
+        "_definitionId": "1da52573-107e-4c2c-b349-d59f791f3d75",
+        "status": "Inaktiv"
+      },
+      "jobType": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==",
+      "email": "remus.rom@micromerce.com",
+      "address": {
+        "country": "DE",
+        "streetName": "Bahnhofsstraße",
+        "postalCode": "20457",
+        "locality": "Hamburg",
+        "houseNumber": "15"
+      },
+      "hoursPerWeek": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==",
+      "_updatedDate": "2024-07-28T11:09:36Z",
+      "photo": "https://19a775a4-db21-4d7c-8f9e-66ee45cf64c1.media.qa.micromerce.com/e33fcab9-70b6-45d3-a15b-8fe9adbcd223/img.png",
+      "targetWorkingHours": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/target-working-hours/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==",
+      "lastname": "Remus",
+      "holidayPerYear": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==",
+      "phone": "+491796604600",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202185153",
+        "totalCostPerCustomer": "160.00",
+        "_createdDate": "1721139436511",
+        "utilisationRateOngoingQuarter": "0.50",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "0.50",
+        "quarterEarnings": [
+          {
+            "earnings": "0.0",
+            "start": "2024-01-01",
+            "name": "Q1",
+            "end": "2024-03-31"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-04-01",
+            "name": "Q2",
+            "end": "2024-06-30"
+          },
+          {
+            "earnings": "0.0",
+            "start": "2024-07-01",
+            "name": "Q3",
+            "end": "2024-09-30"
+          },
+          {
+            "earnings": "160.0",
+            "start": "2024-10-01",
+            "name": "Q4",
+            "end": "2024-12-31"
+          }
+        ],
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "0.50",
+        "utilisationRateYearToDate": "0.50",
+        "utilisationRatePreviousQuarter": "0.00",
+        "_definitionId": "d0448e0f-4225-4196-bd45-8b70730bd397",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "name": "Rom Remus",
+      "earnedVacationDays": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/earned-vacation-days/bXJuPW1ybjpzcnY6ZW50aXR5Ojk3OWU0M2QwLTEwMDgtNDE2OS05OGI5LTgzNDQzMmFkOTRjMzplbnRyaWVzLzk5NDZhNWM3LTA4NDUtNDU3NS04NmUwLTMyYmYzZTc0NmFlMg==",
+      "_id": "9946a5c7-0845-4575-86e0-32bf3e746ae2",
+      "individualTicketDuration": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/bookedTimeOverview/bXJuPW1ybjpzcnY6ZW50aXR5OjFmOGI3YmIyLWNmOTktNDg2NS1iZWUxLTRjNGUwMTI0ODEzZC9lbnRyaWVz",
+      "searchValue": "rom remus mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/current-contract/bxjupw1ybjpzcny6zw50axr5ojk3owu0m2qwltewmdgtnde2os05ogi5ltgzndqzmmfkotrjmzplbnryawvzlzk5ndzhnwm3lta4ndutndu3ns04nmuwltmyymyzztc0nmflmg==",
+      "status": "active"
+    }
+  },
+  {
+    "externals": {
+      "birthday": "1980-10-14",
+      "firstname": "Mustermann",
+      "address": {
+        "country": "DE",
+        "streetName": "Große Reichenstraße",
+        "postalCode": "20457",
+        "locality": "Hamburg",
+        "houseNumber": "14"
+      },
+      "_updatedDate": "2024-07-15T12:13:30Z",
+      "_mrn": "mrn:srv:entity:0681ad04-8e9c-4bf8-a495-0162bf65e4c0:entries/cf6d233a-a9dc-41e0-b7e5-3d96a20ae10f",
+      "_createdDate": "2024-07-15T12:13:30Z",
+      "jobTitle": "Backend Dev",
+      "hourlyRateForProjects": "80",
+      "costsByMonth": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "costsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "0", "month": "2024-04" },
+          { "costs": "0", "month": "2024-05" },
+          { "costs": "0", "month": "2024-06" },
+          { "costs": "0", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_updatedDate": "1723202174187",
+        "_definitionId": "d575547b-2778-4dcd-8551-146f70529e9d",
+        "_createdDate": "1721048454171"
+      },
+      "team": "mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/3d82f5f0-65f5-4b01-a028-4e44334ba94a",
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/fdc450ba-b43f-4010-b7b5-9f830d53732d",
+      "employmentStatus": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "employmentStatus": "Inaktiv",
+        "_updatedDate": "1723202181847",
+        "_definitionId": "610b6b9e-2b87-4d12-a7fb-8d268d0eb0d7",
+        "_createdDate": "1721045610692"
+      },
+      "utilisationRate": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-customer/bXJuPW1ybjpzcnY6ZW50aXR5OjA2ODFhZDA0LThlOWMtNGJmOC1hNDk1LTAxNjJiZjY1ZTRjMDplbnRyaWVzL2NmNmQyMzNhLWE5ZGMtNDFlMC1iN2U1LTNkOTZhMjBhZTEwZg==",
+      "lastname": "Max",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202186979",
+        "totalCostPerCustomer": "0.00",
+        "_createdDate": "1721145574527",
+        "utilisationRateOngoingQuarter": "0.0",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "0.0",
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "NaN",
+        "utilisationRateYearToDate": "0.0",
+        "utilisationRatePreviousQuarter": "0.0",
+        "_definitionId": "2a992875-4676-4dda-b916-3b9113eb13c5",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "name": "Mustermann Max",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/externals-potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5OjA2ODFhZDA0LThlOWMtNGJmOC1hNDk1LTAxNjJiZjY1ZTRjMDplbnRyaWVzL2NmNmQyMzNhLWE5ZGMtNDFlMC1iN2U1LTNkOTZhMjBhZTEwZg==",
+      "_archived": "false",
+      "salutation": "Herr",
+      "_id": "cf6d233a-a9dc-41e0-b7e5-3d96a20ae10f",
+      "email": "maximilian.weber+panda-test@micromerce.com",
+      "status": "active"
+    }
+  },
+  {
+    "externals": {
+      "birthday": "1997-07-12",
+      "firstname": "Jim",
+      "address": {
+        "country": "DE",
+        "streetName": "Musterstraße",
+        "locality": "Frankfurt am Main"
+      },
+      "_updatedDate": "2024-07-28T11:10:19Z",
+      "_mrn": "mrn:srv:entity:0681ad04-8e9c-4bf8-a495-0162bf65e4c0:entries/b9a6c917-1534-4577-a9dd-ef7a4cfebebb",
+      "_createdDate": "2024-04-27T08:54:52Z",
+      "jobTitle": "Backend Dev",
+      "costsByMonth": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "costsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "0", "month": "2024-04" },
+          { "costs": "0", "month": "2024-05" },
+          { "costs": "0", "month": "2024-06" },
+          { "costs": "0", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_updatedDate": "1723202176463",
+        "_definitionId": "d575547b-2778-4dcd-8551-146f70529e9d",
+        "_createdDate": "1714212055093"
+      },
+      "team": "mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/c6041954-91a1-4af3-a91c-b143a591e456",
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a6aace64-770f-4b4a-8959-9ac04f4f2c81",
+      "employmentStatus": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "employmentStatus": "Inaktiv",
+        "_updatedDate": "1723202184559",
+        "_definitionId": "610b6b9e-2b87-4d12-a7fb-8d268d0eb0d7",
+        "_createdDate": "1714312453795"
+      },
+      "lastname": "Goldcoast",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202187177",
+        "totalCostPerCustomer": "240.00",
+        "_createdDate": "1721118017926",
+        "utilisationRateOngoingQuarter": "1.00",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "1.00",
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "1.00",
+        "utilisationRateYearToDate": "1.00",
+        "utilisationRatePreviousQuarter": "0.0",
+        "_definitionId": "2a992875-4676-4dda-b916-3b9113eb13c5",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "1.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "name": "Jim Goldcoast",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/externals-potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5OjA2ODFhZDA0LThlOWMtNGJmOC1hNDk1LTAxNjJiZjY1ZTRjMDplbnRyaWVzL2I5YTZjOTE3LTE1MzQtNDU3Ny1hOWRkLWVmN2E0Y2ZlYmViYg==",
+      "_archived": "false",
+      "_id": "b9a6c917-1534-4577-a9dd-ef7a4cfebebb",
+      "email": "jim.goldcoast.ext@micromerce.com",
+      "status": "active"
+    }
+  },
+  {
+    "externals": {
+      "birthday": "1980-10-14",
+      "firstname": "Sacher",
+      "address": {
+        "country": "DE",
+        "streetName": "Große Reichenstraße",
+        "postalCode": "20457",
+        "locality": "Hamburg",
+        "houseNumber": "14"
+      },
+      "_updatedDate": "2024-07-10T11:02:48Z",
+      "_mrn": "mrn:srv:entity:0681ad04-8e9c-4bf8-a495-0162bf65e4c0:entries/d3f4b992-7234-45b2-ace0-b82cf7c58656",
+      "_createdDate": "2023-07-31T07:29:45Z",
+      "jobTitle": "Backend Dev",
+      "hourlyRateForProjects": "100",
+      "costsByMonth": {
+        "_updatedDate": "1723202177173",
+        "_createdDate": "1713202714363",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "periods": [
+          {
+            "monthlySalary": "5918.181818181818",
+            "start": "2024-04-01",
+            "end": "2024-07-17",
+            "hourlyRate": "50.0",
+            "timeBudget": "420.0"
+          }
+        ],
+        "costsByMonth": [
+          { "costs": "0", "month": "2023-01" },
+          { "costs": "0", "month": "2023-02" },
+          { "costs": "0", "month": "2023-03" },
+          { "costs": "0", "month": "2023-04" },
+          { "costs": "0", "month": "2023-05" },
+          { "costs": "0", "month": "2023-06" },
+          { "costs": "0", "month": "2023-07" },
+          { "costs": "0", "month": "2023-08" },
+          { "costs": "0", "month": "2023-09" },
+          { "costs": "0", "month": "2023-10" },
+          { "costs": "0", "month": "2023-11" },
+          { "costs": "0", "month": "2023-12" },
+          { "costs": "0", "month": "2024-01" },
+          { "costs": "0", "month": "2024-02" },
+          { "costs": "0", "month": "2024-03" },
+          { "costs": "5918", "month": "2024-04" },
+          { "costs": "5918", "month": "2024-05" },
+          { "costs": "5918", "month": "2024-06" },
+          { "costs": "3345", "month": "2024-07" },
+          { "costs": "0", "month": "2024-08" },
+          { "costs": "0", "month": "2024-09" },
+          { "costs": "0", "month": "2024-10" },
+          { "costs": "0", "month": "2024-11" },
+          { "costs": "0", "month": "2024-12" },
+          { "costs": "0", "month": "2025-01" },
+          { "costs": "0", "month": "2025-02" },
+          { "costs": "0", "month": "2025-03" },
+          { "costs": "0", "month": "2025-04" },
+          { "costs": "0", "month": "2025-05" },
+          { "costs": "0", "month": "2025-06" },
+          { "costs": "0", "month": "2025-07" },
+          { "costs": "0", "month": "2025-08" }
+        ],
+        "_definitionId": "d575547b-2778-4dcd-8551-146f70529e9d"
+      },
+      "team": "mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/3d82f5f0-65f5-4b01-a028-4e44334ba94a",
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/a50976c6-fc81-4cc9-af8f-c30d08554307",
+      "employmentStatus": {
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "employmentStatus": "Inaktiv",
+        "_updatedDate": "1723202184655",
+        "_definitionId": "610b6b9e-2b87-4d12-a7fb-8d268d0eb0d7",
+        "_createdDate": "1714312453775"
+      },
+      "utilisationRate": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/time-worked-customer/bXJuPW1ybjpzcnY6ZW50aXR5OjA2ODFhZDA0LThlOWMtNGJmOC1hNDk1LTAxNjJiZjY1ZTRjMDplbnRyaWVzL2QzZjRiOTkyLTcyMzQtNDViMi1hY2UwLWI4MmNmN2M1ODY1Ng==",
+      "lastname": "Julius",
+      "workforceUtilisation": {
+        "_updatedDate": "1723202186903",
+        "totalCostPerCustomer": "0.00",
+        "_createdDate": "1721145585996",
+        "utilisationRateOngoingQuarter": "0.0",
+        "_applicationId": "bbabea28-87a2-4439-bf36-53922115729c",
+        "monthlyCostDifference": "6400.0",
+        "utilisationRateLastTwelveMonths": "0.0",
+        "timeWorkedPreviousQuarter": "0.0",
+        "utilisationRateOverall": "NaN",
+        "utilisationRateYearToDate": "0.0",
+        "utilisationRatePreviousQuarter": "0.0",
+        "_definitionId": "2a992875-4676-4dda-b916-3b9113eb13c5",
+        "lastThreeMonthsIndividually": [
+          { "month": "August", "utilisationRate": "0.00" },
+          { "month": "July", "utilisationRate": "0.00" },
+          { "month": "June", "utilisationRate": "0.00" }
+        ]
+      },
+      "name": "Sacher Julius",
+      "potentialEarnings": "mrn:srv:aggregation:bbabea28-87a2-4439-bf36-53922115729c:aggregations/externals-potential-earnings/bXJuPW1ybjpzcnY6ZW50aXR5OjA2ODFhZDA0LThlOWMtNGJmOC1hNDk1LTAxNjJiZjY1ZTRjMDplbnRyaWVzL2QzZjRiOTkyLTcyMzQtNDViMi1hY2UwLWI4MmNmN2M1ODY1Ng==",
+      "_archived": "false",
+      "salutation": "Herr",
+      "_id": "d3f4b992-7234-45b2-ace0-b82cf7c58656",
+      "email": "maximilian.weber+panda-test@micromerce.com",
+      "status": "active"
+    }
+  },
+  {
+    "teams": {
+      "_updatedDate": "2024-07-30T12:56:45Z",
+      "_mrn": "mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/774cb064-e0c6-448a-a338-4d50087469d1",
+      "_createdDate": "2024-07-30T12:56:45Z",
+      "name": "Dev",
+      "_archived": "false",
+      "_id": "774cb064-e0c6-448a-a338-4d50087469d1",
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/ae00e09d-6d53-4f98-a6be-f74b6dd635e2"
+    }
+  },
+  {
+    "teams": {
+      "_updatedDate": "2024-07-30T12:56:26Z",
+      "_mrn": "mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/aa59773b-4c4e-4304-82c8-274c33d0c8df",
+      "_createdDate": "2024-07-30T12:56:26Z",
+      "name": "Solution",
+      "_archived": "false",
+      "_id": "aa59773b-4c4e-4304-82c8-274c33d0c8df",
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/ae00e09d-6d53-4f98-a6be-f74b6dd635e2"
+    }
+  },
+  {
+    "teams": {
+      "_updatedDate": "2024-07-08T14:29:19Z",
+      "_mrn": "mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/3d82f5f0-65f5-4b01-a028-4e44334ba94a",
+      "_createdDate": "2024-07-08T14:29:19Z",
+      "name": "Test Team 2",
+      "_archived": "false",
+      "_id": "3d82f5f0-65f5-4b01-a028-4e44334ba94a",
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/f56454f7-c20e-42db-8cfa-4cb2b288eeb3",
+      "parentTeam": "mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/c6041954-91a1-4af3-a91c-b143a591e456"
+    }
+  },
+  {
+    "teams": {
+      "_updatedDate": "2024-07-08T14:29:11Z",
+      "_mrn": "mrn:srv:entity:6610b2e8-4c6a-4c38-bf65-50741b30ae31:entries/c6041954-91a1-4af3-a91c-b143a591e456",
+      "_createdDate": "2024-07-08T14:29:11Z",
+      "name": "Test Team",
+      "_archived": "false",
+      "_id": "c6041954-91a1-4af3-a91c-b143a591e456",
+      "_createdBy": "mrn:srv:auth:2b18e55e-e143-4e97-8c76-f7626cab9bbf:users/f56454f7-c20e-42db-8cfa-4cb2b288eeb3"
+    }
+  }
 ]

--- a/src/table-script.tsx
+++ b/src/table-script.tsx
@@ -2,18 +2,21 @@ import {
   MaterialReactTable,
   useMaterialReactTable,
   type MRT_ColumnDef,
-} from "material-react-table";
-import { useMemo } from "react";
-import sourceData from "./source-data.json";
-import type { SourceDataType, TableDataType } from "./types";
-import { format, subMonths } from "date-fns";
+} from "material-react-table"; // Importing Material React Table components and types
+import { useMemo } from "react"; // Importing useMemo hook from React
+import sourceData from "./source-data.json"; // Importing source data from a local JSON file
+import type { SourceDataType, TableDataType } from "./types"; // Importing TypeScript types
+import { format, subMonths } from "date-fns"; // Importing date formatting utilities
 
 //  Helper: Get Net Earning for a specific month (e.g. "June" format: "yyyy-MM")
+//  This function receives the costsByMonth object and a targetMonth string.
+//  It searches for the entry in potentialEarningsByMonth that matches the targetMonth.
+//  If found, it returns the costs with "EUR" appended, otherwise returns "-".
 function getNetEarningsForMonth(
   costsByMonth:
     | {
         _applicationId: string;
-        potentialEarningsByMonth: { costs: string; month: string }[];
+        potentialEarningsByMonth: { costs: string; month: string }[]; // Array of earnings by month
         _updatedDate: string;
         _definitionId: string;
         _createdDate: string;
@@ -21,7 +24,7 @@ function getNetEarningsForMonth(
       }
     | {
         _applicationId: string;
-        potentialEarningsByMonth: { costs: string; month: string }[];
+        potentialEarningsByMonth: { costs: string; month: string }[]; // Array of earnings by month
         _updatedDate: string;
         _definitionId: string;
         _createdDate: string;
@@ -29,7 +32,7 @@ function getNetEarningsForMonth(
       }
     | {
         _applicationId: string;
-        potentialEarningsByMonth: { costs: string; month: string }[];
+        potentialEarningsByMonth: { costs: string; month: string }[]; // Array of earnings by month
         _updatedDate: string;
         _definitionId: string;
         _createdDate: string;


### PR DESCRIPTION
This pull request implements the workforce utilization dashboard as per the challenge requirements.

- Calculates and displays utilization rates (YTD, past 12 months, May/June/July)
- Fetches and displays net earnings for the previous month
- Uses MaterialReactTable for a clean and responsive UI
- Handles missing or undefined data gracefully with fallbacks

The implementation is located in `table-script.tsx`, and is based on the provided `source-data.json`.
